### PR TITLE
Fix: 무제한기간의 재료 등록 기능 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     restart: on-failure
     volumes:
       - mysql_data:/var/lib/mysql  # MySQL 데이터를 저장할 볼륨 정의
+    networks:
+      - yum-server-net
 
   # Spring Boot 서비스 정의
   app:
@@ -23,9 +25,11 @@ services:
       SPRING_DATASOURCE_USERNAME: ${DB_USERNAME}  # 데이터베이스 사용자 이름
       SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}  # 데이터베이스 사용자 비밀번호
     restart: on-failure
+    networks:
+      - yum-server-net
 
 networks:
-  network1:
+  yum-server-net:
     name: yum-server-net
     external: true
 

--- a/src/main/kotlin/com/example/yum_web_server/ingredient/dto/IngredientDtos.kt
+++ b/src/main/kotlin/com/example/yum_web_server/ingredient/dto/IngredientDtos.kt
@@ -50,7 +50,7 @@ data class IngredientRequestDto(
     val startAt : LocalDate
         get() = _startAt!!.toLocalDate()!!
     val endAt : LocalDate?
-        get() = _endAt!!.toLocalDate()
+        get() = _endAt.toLocalDate()
 
     fun toEntity() : Ingredient = Ingredient(
         id = id,

--- a/src/test/kotlin/com/example/yum_web_server/ingredient/controller/IngredientControllerTest.kt
+++ b/src/test/kotlin/com/example/yum_web_server/ingredient/controller/IngredientControllerTest.kt
@@ -178,6 +178,46 @@ class IngredientControllerTest(
                     .jsonPath("$.endAt").isEqualTo("2024-11-19")
             }
         }
+
+        context("기한이 무제한인 새로운 재료가 추가된다면") {
+            val newIngredient = JSONObject()
+                .put("name", "egg")
+                .put("isFreezed", false)
+                .put("category", "egg")
+                .put("startAt", "2024-11-12")
+                .put("endAt",null)
+                .toString()
+            coEvery { ingredientService.saveIngredient(any()) } returns IngredientResponseDto(
+                id = 1,
+                name = "egg",
+                isFreezed = false,
+                category = IngredientCategory.egg,
+                startAt = LocalDate.of(2024, 11, 12),
+                endAt = null,
+            )
+            val result = webTestClient.post()
+                .uri(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(newIngredient)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+            it("201의 응답코드를 반환한다.") {
+                result
+                    .expectStatus().isCreated
+            }
+            it("IngredientResponseDto를 반환한다.") {
+                result
+                    .expectBody<IngredientResponseDto>()
+            }
+            it("새로 추가된 재료를 응답한다.") {
+                result
+                    .expectBody()
+                    .jsonPath("$.name").isEqualTo("egg")
+                    .jsonPath("$.isFreezed").isEqualTo(false)
+                    .jsonPath("$.startAt").isEqualTo("2024-11-12")
+                    .jsonPath("$.endAt").doesNotExist()
+            }
+        }
     }
 
     describe("/api/ingredients로 PUT 요청을 하는 경우에") {


### PR DESCRIPTION
기존에 기간이 무제한인 재료는 endAt 필드가 null로 요청이되나, 에러가 발생하는 상황을 수정했습니다.

이는 DateTime으로 파싱하는 과정이 강제 언래핑 되기 때문입니다. 아래는 수정된 코드입니다.

```kotlin
    val endAt : LocalDate?
        get() = _endAt.toLocalDate()
```

### 체크리스트
----
- [x] 테스트가 잘 통과하는지?